### PR TITLE
[Refactor] 템플릿 적용 안됨 문제 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,11 @@
+---
+name: Bug
+about: 버그 제보
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
 ## 🐛 버그 설명
 - 어떤 문제가 발생했는지 설명
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,3 +1,15 @@
+---
+name: Feature
+about: 기능 요청
+title: "[FEATURE] "
+labels: feature
+assignees: ''
+---
+
+## ✨ 기능 설명
+
+## 🔧 리팩토링 내용
+
 ## 📌 기능 설명
 - 어떤 기능인지 간단히 설명
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,3 +1,13 @@
+---
+name: Refactor
+about: 리팩토링
+title: "[REFACTOR] "
+labels: refactor
+assignees: ''
+---
+
+## 🔧 리팩토링 내용
+
 ## 🔧 리팩토링 대상
 - 어떤 부분을 개선하는지
 


### PR DESCRIPTION
## 📌 개요
GitHub Issue Template이 적용되지 않고, "New Issue" 클릭 시 템플릿 선택 없이 바로 이슈가 생성되는 문제를 해결합니다.

## 📌 작업 내용
- Issue Template 파일에 front matter 추가
- GitHub에서 템플릿으로 정상 인식되도록 수정

## 📌 관련 이슈
- Closes #9 