### PR TITLE
[Feature] S3 이미지 업로드 및 CloudFront 조회 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // AWS
+    implementation platform("software.amazon.awssdk:bom:2.25.62")
+    implementation "software.amazon.awssdk:s3"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/emotory/backend/global/config/S3Config.java
+++ b/src/main/java/com/emotory/backend/global/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.emotory.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider())
+                .build();
+    }
+
+    private StaticCredentialsProvider credentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+        );
+    }
+}

--- a/src/main/java/com/emotory/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/emotory/backend/global/config/SecurityConfig.java
@@ -25,6 +25,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).permitAll()
 
+                        // S3 업로드 허용
+                        .requestMatchers("/api/s3/**").permitAll()
+
                         // 전체 허용
                         .anyRequest().permitAll()
                 );

--- a/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     // 400 error
     INVALID_INPUT(400, "잘못된 입력 값입니다."),
     NO_FEED_UPDATE_CONTENT_EXCEPTION(400, "수정할 내용이 없습니다."),
+    UNSUPPORTED_IMAGE_TYPE(400, "지원하지 않는 이미지 타입입니다."),
+    UNSUPPORTED_FILE_FORMAT(400, "지원하지 않는 파일 형식입니다."),
 
     // 401 error
     UNAUTHORIZED(401, "인증이 필요합니다."),
@@ -20,9 +22,11 @@ public enum ErrorCode {
 
     // 404 error
     NOT_FOUND(404, "존재하지 않는 리소스입니다."),
+    S3_FILE_NOT_FOUND(404, "S3 파일을 찾을 수 없습니다."),
 
     // 500 error
-    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
+    S3_DOWNLOAD_FAILED(500, "S3 파일 다운로드에 실패했습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/emotory/backend/global/exception/s3/S3DownloadFailedException.java
+++ b/src/main/java/com/emotory/backend/global/exception/s3/S3DownloadFailedException.java
@@ -1,0 +1,8 @@
+package com.emotory.backend.global.exception.s3;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class S3DownloadFailedException extends CustomException {
+    public S3DownloadFailedException() { super(ErrorCode.S3_DOWNLOAD_FAILED); }
+}

--- a/src/main/java/com/emotory/backend/global/exception/s3/S3FileNotFoundException.java
+++ b/src/main/java/com/emotory/backend/global/exception/s3/S3FileNotFoundException.java
@@ -1,0 +1,8 @@
+package com.emotory.backend.global.exception.s3;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class S3FileNotFoundException extends CustomException {
+    public S3FileNotFoundException() { super(ErrorCode.S3_FILE_NOT_FOUND); }
+}

--- a/src/main/java/com/emotory/backend/global/exception/s3/UnsupportedFileFormat.java
+++ b/src/main/java/com/emotory/backend/global/exception/s3/UnsupportedFileFormat.java
@@ -1,0 +1,10 @@
+package com.emotory.backend.global.exception.s3;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class UnsupportedFileFormat extends CustomException {
+    public UnsupportedFileFormat() {
+        super(ErrorCode.UNSUPPORTED_FILE_FORMAT);
+    }
+}

--- a/src/main/java/com/emotory/backend/global/exception/s3/UnsupportedImageType.java
+++ b/src/main/java/com/emotory/backend/global/exception/s3/UnsupportedImageType.java
@@ -1,0 +1,10 @@
+package com.emotory.backend.global.exception.s3;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class UnsupportedImageType extends CustomException {
+    public UnsupportedImageType() {
+        super(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+    }
+}

--- a/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
@@ -1,0 +1,30 @@
+package com.emotory.backend.global.s3.controller;
+
+import com.emotory.backend.global.s3.dto.request.PresignedUploadRequest;
+import com.emotory.backend.global.s3.dto.response.PresignedUrlResponse;
+import com.emotory.backend.global.s3.service.PresignedS3Service;
+import com.emotory.backend.global.s3.service.S3FileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URL;
+
+@RestController
+@RequestMapping("/api/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final PresignedS3Service presignedS3Service;
+    private final S3FileService s3FileService;
+
+    @PostMapping("/presigned-upload")
+    public PresignedUrlResponse getPreSignedUploadUrl(
+            @Valid @RequestBody PresignedUploadRequest request
+    ) {
+        String key = s3FileService.createKey(request.type(), request.contentType());
+        URL uploadUrl = presignedS3Service.generatePreSignedUploadUrl(key, request.contentType());
+
+        return new PresignedUrlResponse(uploadUrl.toString(), key);
+    }
+}

--- a/src/main/java/com/emotory/backend/global/s3/dto/request/PresignedUploadRequest.java
+++ b/src/main/java/com/emotory/backend/global/s3/dto/request/PresignedUploadRequest.java
@@ -1,0 +1,9 @@
+package com.emotory.backend.global.s3.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUploadRequest(
+        @NotBlank String type,
+        @NotBlank String contentType
+) {
+}

--- a/src/main/java/com/emotory/backend/global/s3/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/emotory/backend/global/s3/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.emotory.backend.global.s3.dto.response;
+
+public record PresignedUrlResponse (
+        String uploadUrl,
+        String fileKey
+) {
+}

--- a/src/main/java/com/emotory/backend/global/s3/service/PresignedS3Service.java
+++ b/src/main/java/com/emotory/backend/global/s3/service/PresignedS3Service.java
@@ -1,0 +1,45 @@
+package com.emotory.backend.global.s3.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.net.URL;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class PresignedS3Service {
+
+    private final S3Presigner presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.presigned-url.expiration-minutes}")
+    private long expirationMinutes;
+
+    public URL generatePreSignedUploadUrl(
+            String key,
+            String contentType
+    ) {
+
+        PutObjectRequest objectRequest =
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .contentType(contentType)
+                        .build();
+
+        PresignedPutObjectRequest presignedRequest =
+                presigner.presignPutObject(builder -> builder
+                        .signatureDuration(Duration.ofMinutes(expirationMinutes))
+                        .putObjectRequest(objectRequest)
+                );
+
+        return presignedRequest.url();
+    }
+}

--- a/src/main/java/com/emotory/backend/global/s3/service/S3FileService.java
+++ b/src/main/java/com/emotory/backend/global/s3/service/S3FileService.java
@@ -1,0 +1,62 @@
+package com.emotory.backend.global.s3.service;
+
+import com.emotory.backend.global.exception.s3.UnsupportedFileFormat;
+import com.emotory.backend.global.exception.s3.UnsupportedImageType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3FileService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+    public String createKey(String type, String contentType) {
+
+        String extension = extractExtension(contentType);
+
+        String uuid = UUID.randomUUID().toString();
+
+        return switch (type) {
+            case "face" ->
+                    "faces/" + uuid + "." + extension;
+            case "generated" ->
+                    "generated/" + uuid + "." + extension;
+            default ->
+                    throw new UnsupportedImageType();
+        };
+    }
+
+    /**
+     * generated/ 경로의 합성 결과 이미지만 CloudFront 조회 URL로 변환
+     */
+    public String createGeneratedImageUrl(String key) {
+
+        if (key == null || !key.startsWith("generated/")) {
+            throw new UnsupportedImageType();
+        }
+
+        return "https://" + cloudFrontDomain + "/" + key;
+    }
+
+    private String extractExtension(String contentType) {
+
+        return switch (contentType) {
+            case "image/png" -> "png";
+            case "image/jpeg" -> "jpg";
+            case "image/webp" -> "webp";
+            default ->
+                    throw new UnsupportedFileFormat();
+        };
+    }
+}

--- a/src/main/java/com/emotory/backend/global/s3/service/S3StorageService.java
+++ b/src/main/java/com/emotory/backend/global/s3/service/S3StorageService.java
@@ -1,0 +1,86 @@
+package com.emotory.backend.global.s3.service;
+
+import com.emotory.backend.global.exception.s3.S3DownloadFailedException;
+import com.emotory.backend.global.exception.s3.S3FileNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class S3StorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * byte[] 기반 업로드
+     * 이미지 전체가 이미 메모리에 올라와 있는 경우 사용
+     */
+    public void uploadFile(
+            String key,
+            byte[] fileBytes,
+            String contentType
+    ) {
+
+        PutObjectRequest request =
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .contentType(contentType)
+                        .build();
+
+        s3Client.putObject(
+                request,
+                RequestBody.fromBytes(fileBytes)
+        );
+    }
+
+    /**
+     * 얼굴사진의 보호를 위한 삭제 메서드
+     */
+    public void deleteFile(String key) {
+
+        if (key == null || key.isBlank()) {
+            return;
+        }
+
+        DeleteObjectRequest deleteRequest =
+                DeleteObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    /**
+     * 이미지 합성을 위한 S3에서 사용자 사진 다운받는 메서드
+     */
+    public byte[] downloadFile(String key) {
+
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        try (ResponseInputStream<GetObjectResponse> inputStream =
+                     s3Client.getObject(request)) {
+            return inputStream.readAllBytes();
+
+        } catch (NoSuchKeyException e) {
+            throw new S3FileNotFoundException();
+
+        } catch (IOException | S3Exception e) {
+            throw new S3DownloadFailedException();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,17 @@ server:
 logging:
   level:
     root: INFO
+
+cloud:
+  aws:
+    region:
+      static: ${AWS_REGION}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      presigned-url:
+        expiration-minutes: 10 # presigned URL 만료 시간 (분 단위)
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN}


### PR DESCRIPTION
## 📌 개요
- S3 기반 이미지 업로드/저장 기능을 구현했습니다.
- 클라이언트는 presigned URL을 통해 사용자 얼굴 이미지를 S3에 직접 업로드할 수 있습니다.
- 서버는 S3에 저장된 이미지를 다운로드하고, AI 합성 결과 이미지를 다시 S3에 업로드할 수 있도록 공통 S3 서비스를 추가했습니다.
- 합성 결과 이미지는 CloudFront URL로 조회할 수 있도록 구조를 추가했습니다.

## 📌 작업 내용
- AWS S3 설정 추가
  - `S3Client` Bean 등록
  - `S3Presigner` Bean 등록
  - AWS region, credentials, bucket 설정 추가

- Presigned Upload URL 발급 API 추가
  - `POST /api/s3/presigned-upload`
  - 요청값: `type`, `contentType`
  - 응답값: `uploadUrl`, `fileKey`

- S3 파일 key 생성 로직 추가
  - `face` 타입은 `faces/{uuid}.{extension}` 경로로 생성
  - `generated` 타입은 `generated/{uuid}.{extension}` 경로로 생성
  - 지원 파일 형식: `image/png`, `image/jpeg`, `image/webp`

- S3 저장소 서비스 추가
  - 서버 내부 이미지 업로드
  - S3 이미지 다운로드
  - S3 이미지 삭제

- CloudFront URL 생성 로직 추가
  - `generated/` 경로의 합성 결과 이미지만 CloudFront URL 생성 허용
  - 원본 얼굴 이미지인 `faces/` 경로는 외부 URL 생성 대상에서 제외

- S3 관련 예외 처리 추가
  - 지원하지 않는 이미지 타입
  - 지원하지 않는 파일 형식
  - S3 파일 없음
  - S3 다운로드 실패

## 📌 변경 사항
- Controller:
  - `S3Controller`
    - presigned upload URL 발급 API 추가

- Service:
  - `S3FileService`
    - 이미지 타입별 S3 key 생성
    - 합성 결과 이미지 CloudFront URL 생성
  - `PresignedS3Service`
    - presigned upload URL 생성
  - `S3StorageService`
    - S3 업로드
    - S3 다운로드
    - S3 삭제

- DTO:
  - `PresignedUploadRequest`
  - `PresignedUrlResponse`

- Config:
  - `S3Config`
  - `application.yml` S3/CloudFront 설정 추가

- Exception:
  - `UnsupportedImageType`
  - `UnsupportedFileFormat`
  - `S3FileNotFoundException`
  - `S3DownloadFailedException`

## 📌 관련 이슈
- Closes #16

## PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [ ] 리뷰 코멘트를 반영했는가