### PR TITLE
[Bug] ssh_key 못읽는 오류 -> 버전 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
 
       # 7. EC2 배포
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@v0.1.6
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.WAS_HOST }}
           username: ubuntu


### PR DESCRIPTION
## 📌 개요
- GitHub Actions 기반 CI/CD 배포 환경 설정 및 EC2 자동 배포 구성

📌 작업 내용
- 내부적으로:
  - SSH 연결
  - private key parsing
  - 원격 서버 명령 실행
을 대신 처리해주는 GitHub Action 버전 수정

## 📌 관련 이슈
- Closes #20 

## PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [ ] 리뷰 코멘트를 반영했는가