### PR TITLE
[Feature] 멤버 이름 조회 api 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.emotory.backend.domain.member.controller;
+
+import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
+import com.emotory.backend.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자")
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "사용자 이름 조회", description = "사용자 ID로 사용자 이름을 조회합니다.")
+    @GetMapping("/{memberId}")
+    public MemberNameResponse getMemberName(@PathVariable Long memberId) {
+        return memberService.getMemberName(memberId);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
@@ -1,24 +1,22 @@
 package com.emotory.backend.domain.member.controller;
 
+import com.emotory.backend.domain.member.controller.docs.MemberControllerDocs;
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import com.emotory.backend.domain.member.service.MemberService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "사용자")
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
-public class MemberController {
+public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
 
-    @Operation(summary = "사용자 이름 조회", description = "사용자 ID로 사용자 이름을 조회합니다.")
+    @Override
     @GetMapping("/{memberId}")
     public MemberNameResponse getMemberName(@PathVariable Long memberId) {
         return memberService.getMemberName(memberId);

--- a/src/main/java/com/emotory/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,0 +1,12 @@
+package com.emotory.backend.domain.member.controller.docs;
+
+import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "사용자")
+public interface MemberControllerDocs {
+
+    @Operation(summary = "사용자 이름 조회", description = "사용자 ID로 사용자 이름을 조회합니다.")
+    MemberNameResponse getMemberName(Long memberId);
+}

--- a/src/main/java/com/emotory/backend/domain/member/dto/response/MemberNameResponse.java
+++ b/src/main/java/com/emotory/backend/domain/member/dto/response/MemberNameResponse.java
@@ -1,0 +1,16 @@
+package com.emotory.backend.domain.member.dto.response;
+
+import com.emotory.backend.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 이름 조회 응답")
+public record MemberNameResponse (
+
+        @Schema(description = "사용자 이름", example = "장정훈")
+        String name
+) {
+
+    public static MemberNameResponse from(Member member) {
+        return new MemberNameResponse(member.getName());
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/emotory/backend/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.emotory.backend.domain.member.exception;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class MemberNotFoundException extends CustomException {
+
+    public MemberNotFoundException() {
+        super(ErrorCode.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/emotory/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.emotory.backend.domain.member.repository;
+
+import com.emotory.backend.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.emotory.backend.domain.member.service;
+
+import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
+import com.emotory.backend.domain.member.entity.Member;
+import com.emotory.backend.domain.member.repository.MemberRepository;
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberNameResponse getMemberName(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        return MemberNameResponse.from(member);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
@@ -2,9 +2,8 @@ package com.emotory.backend.domain.member.service;
 
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import com.emotory.backend.domain.member.entity.Member;
+import com.emotory.backend.domain.member.exception.MemberNotFoundException;
 import com.emotory.backend.domain.member.repository.MemberRepository;
-import com.emotory.backend.global.exception.CustomException;
-import com.emotory.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,7 @@ public class MemberService {
 
     public MemberNameResponse getMemberName(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+                .orElseThrow(MemberNotFoundException::new);
 
         return MemberNameResponse.from(member);
     }


### PR DESCRIPTION
## 📌 개요
- #34 

## 📌 작업 내용
  - `memberId`를 기반으로 사용자 이름을 조회하는 GET API를 구현했습니다.
  - Swagger 문서에서 사용자 API 그룹과 응답 스키마를 확인할 수 있도록 어노테이션을 추가했습니다.

  ## 📌 변경 사항
  - Controller:
    - `GET /api/members/{memberId}` 엔드포인트 추가
    - `@Tag`, `@Operation`을 사용해 Swagger 문서 설명 추가

  - Service:
    - `memberId`로 `Member`를 조회하는 비즈니스 로직 추가
    - 존재하지 않는 사용자일 경우 `CustomException(ErrorCode.NOT_FOUND)` 발생 처리
    - 조회된 `Member`를 `MemberNameResponse`로 변환

  - Repository:
    - `MemberRepository` 추가
    - `JpaRepository<Member, Long>`를 상속해 기본 조회 기능 사용

  - DTO:
    - `MemberNameResponse` 추가
    - 사용자 이름만 응답하도록 `name` 필드 구성
    - `@Schema`를 사용해 Swagger 응답 스키마 설명 추가
  
## PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [ ] 리뷰 코멘트를 반영했는가

<img width="1314" height="743" alt="image" src="https://github.com/user-attachments/assets/8a647ab4-e494-4819-bb5e-711f7f1d384a" />

<img width="1070" height="793" alt="image" src="https://github.com/user-attachments/assets/a201bfaf-99a8-4fd4-aa39-2a9c88991845" />
