### PR TITLE
[Feature] 유저 약관 동의 api 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.emotory.backend.domain.member.controller;
+
+import com.emotory.backend.domain.member.dto.request.MemberPrivacyRequest;
+import com.emotory.backend.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "사용자")
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "사용자 약관 동의", description = "사용자 ID로 개인정보 동의 여부를 수정합니다.")
+    @PatchMapping("/{memberId}/privacy")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updatePrivacy(
+            @PathVariable Long memberId,
+            @Valid @RequestBody MemberPrivacyRequest request
+    ) {
+        memberService.updatePrivacy(memberId, request);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/member/dto/request/MemberPrivacyRequest.java
+++ b/src/main/java/com/emotory/backend/domain/member/dto/request/MemberPrivacyRequest.java
@@ -1,0 +1,8 @@
+package com.emotory.backend.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberPrivacyRequest (
+    @NotNull(message = "개인정보 동의 여부는 필수입니다.")
+    Boolean isPrivacyAgreed
+){}

--- a/src/main/java/com/emotory/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/emotory/backend/domain/member/entity/Member.java
@@ -33,6 +33,11 @@ public class Member extends BaseTimeEntity {
     @Column(name = "is_privacy_agreed", nullable = false)
     private Boolean isPrivacyAgreed;
 
-    @Column(name = "privacy_agreed_at", nullable = false)
+    @Column(name = "privacy_agreed_at")
     private LocalDateTime privacyAgreedAt;
+
+    public void updatePrivacyAgreement(Boolean isPrivacyAgreed, LocalDateTime privacyAgreedAt) {
+        this.isPrivacyAgreed = isPrivacyAgreed;
+        this.privacyAgreedAt = privacyAgreedAt;
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/emotory/backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.emotory.backend.domain.member.repository;
+
+import com.emotory.backend.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
@@ -1,0 +1,29 @@
+package com.emotory.backend.domain.member.service;
+
+import com.emotory.backend.domain.member.dto.request.MemberPrivacyRequest;
+import com.emotory.backend.domain.member.entity.Member;
+import com.emotory.backend.domain.member.repository.MemberRepository;
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void updatePrivacy(Long memberId, MemberPrivacyRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        LocalDateTime privacyAgreedAt = request.isPrivacyAgreed() ? LocalDateTime.now() : null;
+
+        member.updatePrivacyAgreement(request.isPrivacyAgreed(), privacyAgreedAt);
+    }
+}


### PR DESCRIPTION
## 📌 개요
- #37 
- 사용자 개인정보 동의 여부를 수정하는 API를 추가했습니다.

## 📌 작업 내용
  - `PATCH /api/members/{memberId}/privacy` API 추가
  - 개인정보 동의 여부에 따라 동의 시각을 저장하거나 초기화하도록 구현
  - 동의 철회가 가능하도록 `privacy_agreed_at` 컬럼의 nullable 정책 반영

  ## 📌 변경 사항
  - Controller:
    - `MemberController` 추가
    - `PATCH /api/members/{memberId}/privacy` 엔드포인트 추가
    - 성공 시 `204 No Content` 반환

  - Service:
    - `MemberService` 추가
    - `memberId`로 사용자 조회 후 개인정보 동의 여부 수정
    - 동의 시 `privacyAgreedAt`을 현재 시각으로 저장
    - 동의 철회 시 `privacyAgreedAt`을 `null`로 변경

  - Repository:
    - `MemberRepository` 추가
    - `JpaRepository<Member, Long>` 상속

## PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [] 리뷰 코멘트를 반영했는가