### PR TITLE
[Feature] 이야기 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/story/controller/StoryController.java
+++ b/src/main/java/com/emotory/backend/domain/story/controller/StoryController.java
@@ -1,0 +1,23 @@
+package com.emotory.backend.domain.story.controller;
+
+import com.emotory.backend.domain.story.controller.docs.StoryControllerDocs;
+import com.emotory.backend.domain.story.dto.response.StoryListResponse;
+import com.emotory.backend.domain.story.service.StoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stories")
+public class StoryController implements StoryControllerDocs {
+
+    private final StoryService storyService;
+
+    @Override
+    @GetMapping
+    public StoryListResponse getStories() {
+        return storyService.getStories();
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/story/controller/docs/StoryControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/story/controller/docs/StoryControllerDocs.java
@@ -1,0 +1,12 @@
+package com.emotory.backend.domain.story.controller.docs;
+
+import com.emotory.backend.domain.story.dto.response.StoryListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "이야기")
+public interface StoryControllerDocs {
+
+    @Operation(summary = "이야기 목록 조회")
+    StoryListResponse getStories();
+}

--- a/src/main/java/com/emotory/backend/domain/story/dto/response/StoryListResponse.java
+++ b/src/main/java/com/emotory/backend/domain/story/dto/response/StoryListResponse.java
@@ -1,0 +1,17 @@
+package com.emotory.backend.domain.story.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "이야기 목록 조회 응답")
+public record StoryListResponse(
+
+        @Schema(description = "이야기 목록")
+        List<StoryResponse> stories
+) {
+
+    public static StoryListResponse from(List<StoryResponse> stories) {
+        return new StoryListResponse(stories);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/story/dto/response/StoryResponse.java
+++ b/src/main/java/com/emotory/backend/domain/story/dto/response/StoryResponse.java
@@ -1,0 +1,22 @@
+package com.emotory.backend.domain.story.dto.response;
+
+import com.emotory.backend.domain.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "스토리 목록 조회 응답")
+public record StoryResponse(
+
+        @Schema(description = "스토리 ID", example = "1")
+        Long storyId,
+
+        @Schema(description = "스토리 제목", example = "정훈이의 감정여행~")
+        String title,
+
+        @Schema(description = "스토리 설명", example = "숨속을 탐험하며 감정을 알아가는 이야기")
+        String description
+) {
+
+    public static StoryResponse from(Story story) {
+        return new StoryResponse(story.getId(), story.getTitle(), story.getDescription());
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/emotory/backend/domain/story/repository/StoryRepository.java
@@ -1,0 +1,8 @@
+package com.emotory.backend.domain.story.repository;
+
+
+import com.emotory.backend.domain.story.entity.Story;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoryRepository extends JpaRepository<Story, Long> {
+}

--- a/src/main/java/com/emotory/backend/domain/story/service/StoryService.java
+++ b/src/main/java/com/emotory/backend/domain/story/service/StoryService.java
@@ -1,0 +1,27 @@
+package com.emotory.backend.domain.story.service;
+
+import com.emotory.backend.domain.story.dto.response.StoryListResponse;
+import com.emotory.backend.domain.story.dto.response.StoryResponse;
+import com.emotory.backend.domain.story.repository.StoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoryService {
+
+    private final StoryRepository storyRepository;
+
+    public StoryListResponse getStories() {
+        List<StoryResponse> stories = storyRepository.findAll()
+                .stream()
+                .map(StoryResponse::from)
+                .toList();
+
+        return StoryListResponse.from(stories);
+    }
+}


### PR DESCRIPTION
## 📌 개요
- #39 
- 스토리 목록 조회 API를 구현했습니다.
- GET /api/stories 요청 시 전체 스토리의 storyId, title, description을 반환합니다.
- 응답은 stories 필드로 감싼 객체 형태로 반환되도록 구성했습니다.

## 📌 작업 내용
- 스토리 목록 조회용 Controller, Service, Repository를 추가했습니다.
- Story 엔티티를 StoryResponse DTO로 변환하도록 구현했습니다.
- 목록 응답을 { "stories": [...] } 형태로 반환하기 위해 StoryListResponse를 추가했습니다.
- Swagger 문서화를 위한 StoryControllerDocs를 추가했습니다.

## 📌 변경 사항
  - Controller:
      - StoryController 추가
      - GET /api/stories endpoint 추가
      - StoryControllerDocs를 구현하여 Swagger 문서와 연결
  - Service:
      - StoryService 추가
      - storyRepository.findAll()을 통해 전체 스토리 조회
      - 조회된 Story 목록을 StoryResponse로 변환
      - StoryListResponse로 감싸 응답 반환
  - Repository:
      - StoryRepository 추가
      - JpaRepository<Story, Long> 상속
      - 기본 제공 findAll()을 사용해 스토리 목록 조회

<img width="952" height="888" alt="image" src="https://github.com/user-attachments/assets/4384bb7b-70d2-41a8-a73b-699be79b41bf" />


## PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [ ] 리뷰 코멘트를 반영했는가