### PR TITLE
[Feature] 멤버 생성 API 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
@@ -1,13 +1,13 @@
 package com.emotory.backend.domain.member.controller;
 
 import com.emotory.backend.domain.member.controller.docs.MemberControllerDocs;
+import com.emotory.backend.domain.member.dto.request.MemberCreateRequest;
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import com.emotory.backend.domain.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
@@ -15,6 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
+
+    @Override
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public void createMember(@Valid @RequestBody MemberCreateRequest request) {
+        memberService.createMember(request);
+    }
 
     @Override
     @GetMapping("/{memberId}")

--- a/src/main/java/com/emotory/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,11 +1,15 @@
 package com.emotory.backend.domain.member.controller.docs;
 
+import com.emotory.backend.domain.member.dto.request.MemberCreateRequest;
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "사용자")
 public interface MemberControllerDocs {
+
+    @Operation(summary = "사용자 생성", description = "사용자 이름, 얼굴 이미지 URL, 개인정보 동의 여부를 저장합니다.")
+    void createMember(MemberCreateRequest request);
 
     @Operation(summary = "사용자 이름 조회", description = "사용자 ID로 사용자 이름을 조회합니다.")
     MemberNameResponse getMemberName(Long memberId);

--- a/src/main/java/com/emotory/backend/domain/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/emotory/backend/domain/member/dto/request/MemberCreateRequest.java
@@ -1,0 +1,24 @@
+package com.emotory.backend.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "사용자 생성 요청")
+public record MemberCreateRequest(
+
+        @Schema(description = "사용자 이름", example = "장정훈")
+        @NotBlank(message = "사용자 이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "사용자 얼굴 이미지 URL", example = "https://example.com/face.png")
+        @NotBlank(message = "사용자 얼굴 이미지 URL은 필수입니다.")
+        String faceImageUrl,
+
+        @Schema(description = "개인정보 동의 여부", example = "true")
+        @NotNull(message = "개인정보 동의 여부는 필수입니다.")
+        @AssertTrue(message = "개인정보 약관 동의는 필수입니다.")
+        Boolean isPrivacyAgreed
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/emotory/backend/domain/member/entity/Member.java
@@ -21,11 +21,12 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column
     private Long age;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String role;
+    private MemberRole role;
 
     @Column(name = "face_image_url", nullable = false)
     private String faceImageUrl;
@@ -35,4 +36,22 @@ public class Member extends BaseTimeEntity {
 
     @Column(name = "privacy_agreed_at", nullable = false)
     private LocalDateTime privacyAgreedAt;
+
+    private Member(
+            String name,
+            String faceImageUrl,
+            MemberRole role,
+            Boolean isPrivacyAgreed,
+            LocalDateTime privacyAgreedAt
+    ) {
+        this.name = name;
+        this.faceImageUrl = faceImageUrl;
+        this.role = role;
+        this.isPrivacyAgreed = isPrivacyAgreed;
+        this.privacyAgreedAt = privacyAgreedAt;
+    }
+
+    public static Member create(String name, String faceImageUrl) {
+        return new Member(name, faceImageUrl, MemberRole.USER, true, LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/emotory/backend/domain/member/entity/MemberRole.java
@@ -1,0 +1,5 @@
+package com.emotory.backend.domain.member.entity;
+
+public enum MemberRole {
+    USER
+}

--- a/src/main/java/com/emotory/backend/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/emotory/backend/domain/member/exception/MemberNotFoundException.java
@@ -6,6 +6,6 @@ import com.emotory.backend.global.exception.ErrorCode;
 public class MemberNotFoundException extends CustomException {
 
     public MemberNotFoundException() {
-        super(ErrorCode.NOT_FOUND);
+        super(ErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.emotory.backend.domain.member.service;
 
+import com.emotory.backend.domain.member.dto.request.MemberCreateRequest;
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import com.emotory.backend.domain.member.entity.Member;
 import com.emotory.backend.domain.member.exception.MemberNotFoundException;
@@ -14,6 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createMember(MemberCreateRequest request) {
+        Member member = Member.create(request.name(), request.faceImageUrl());
+        memberRepository.save(member);
+    }
 
     public MemberNameResponse getMemberName(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/emotory/backend/domain/member/service/MemberService.java
@@ -3,7 +3,7 @@ package com.emotory.backend.domain.member.service;
 import com.emotory.backend.domain.member.dto.request.MemberCreateRequest;
 import com.emotory.backend.domain.member.dto.response.MemberNameResponse;
 import com.emotory.backend.domain.member.entity.Member;
-import com.emotory.backend.domain.member.exception.MemberNotFoundException;
+import com.emotory.backend.global.exception.member.MemberNotFoundException;
 import com.emotory.backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/emotory/backend/domain/playSession/service/PlaySessionService.java
+++ b/src/main/java/com/emotory/backend/domain/playSession/service/PlaySessionService.java
@@ -1,7 +1,7 @@
 package com.emotory.backend.domain.playSession.service;
 
 import com.emotory.backend.domain.member.entity.Member;
-import com.emotory.backend.domain.member.exception.MemberNotFoundException;
+import com.emotory.backend.global.exception.member.MemberNotFoundException;
 import com.emotory.backend.domain.member.repository.MemberRepository;
 import com.emotory.backend.domain.playSession.dto.request.PlaySessionCreateRequest;
 import com.emotory.backend.domain.playSession.dto.response.PlaySessionResponse;

--- a/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
     // 404 error
     NOT_FOUND(404, "존재하지 않는 리소스입니다."),
+    MEMBER_NOT_FOUND(404, "회원을 찾을 수 없습니다."),
     S3_FILE_NOT_FOUND(404, "S3 파일을 찾을 수 없습니다."),
 
     // 500 error

--- a/src/main/java/com/emotory/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/emotory/backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.emotory.backend.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,6 +22,25 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(code.getStatus())
                 .body(new ErrorResponse(code.getStatus(), code.getMessage()));
+    }
+
+    /**
+     * @Valid 검증 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+
+        log.warn("ValidationException 발생: {}", message);
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getStatus(), message));
     }
 
     /**

--- a/src/main/java/com/emotory/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/emotory/backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.emotory.backend.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -41,6 +42,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getStatus())
                 .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getStatus(), message));
+    }
+
+    /**
+     * 요청 본문 파싱 예외 처리
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException 발생: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.getStatus(), ErrorCode.INVALID_INPUT.getMessage()));
     }
 
     /**

--- a/src/main/java/com/emotory/backend/global/exception/member/MemberNotFoundException.java
+++ b/src/main/java/com/emotory/backend/global/exception/member/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package com.emotory.backend.domain.member.exception;
+package com.emotory.backend.global.exception.member;
 
 import com.emotory.backend.global.exception.CustomException;
 import com.emotory.backend.global.exception.ErrorCode;


### PR DESCRIPTION
## 📌 개요
- #41 

  - 사용자 생성 API를 구현했습니다.
  - 약관 동의 이후 사용자 이름과 얼굴 이미지 URL을 받아 Member를 생성하도록 처리했습니다.
  - 권한 값은 MemberRole enum으로 관리하도록 변경했습니다.

  ## 📌 작업 내용

  - POST /api/members 사용자 생성 API 추가
  - 사용자 생성 request DTO 추가
  - name, faceImageUrl, isPrivacyAgreed 입력값 검증 추가
  - 약관 동의 여부가 false이거나 누락된 경우 400 Bad Request 응답 처리
  - 사용자 생성 시 기본 권한을 USER로 저장
  - 사용자 생성 시 약관 동의 여부와 약관 동의 시각 저장
  - age는 생성 시 입력받지 않으므로 nullable 허용
  - validation 예외 처리를 위한 global exception handler 추가

  ## 📌 변경 사항

  - Controller:
      - POST /api/members 엔드포인트 추가
      - @Valid @RequestBody MemberCreateRequest로 사용자 생성 요청 검증
      - 성공 시 201 Created 응답
  - Service:
      - createMember() 추가
      - request 값을 기반으로 Member 엔티티 생성 후 저장
  - Repository:
      - 기존 MemberRepository 사용
      - 별도 변경 없음
  - Entity:
      - Member.create() 정적 팩토리 메서드 추가
      - age nullable 허용
      - role을 String에서 MemberRole enum으로 변경
      - 생성 시 MemberRole.USER, isPrivacyAgreed = true, privacyAgreedAt = LocalDateTime.now() 저장
  - DTO:
      - MemberCreateRequest 추가
      - name, faceImageUrl, isPrivacyAgreed 필드 검증 추가
  - Exception:
      - MethodArgumentNotValidException 처리 추가
      - DTO validation 실패 시 400 Bad Request 응답

<img width="971" height="524" alt="image" src="https://github.com/user-attachments/assets/dc03be3b-3f9f-47de-a181-bf11e34b36a7" />

<img width="720" height="730" alt="image" src="https://github.com/user-attachments/assets/b4722be1-af95-4952-a039-3e4ef528910c" />


  ## PR 체크리스트

  - [x] 이슈와 연결했는가
  - [x] 기능 단위로 작성했는가
  - [x] 테스트를 수행했는가
  - [x] 불필요한 코드가 없는가
  - [ ] 리뷰 코멘트를 반영했는가