### PR TITLE
[Feature] 플레이 기록 조회 API 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
@@ -1,0 +1,24 @@
+package com.emotory.backend.domain.playHistory.controller;
+
+import com.emotory.backend.domain.playHistory.dto.response.PlayHistoryListResponse;
+import com.emotory.backend.domain.playHistory.service.PlayHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/play-sessions/{playSessionId}/histories")
+public class PlayHistoryController {
+
+    private final PlayHistoryService playHistoryService;
+
+    @GetMapping
+    public PlayHistoryListResponse getPlayHistories(
+            @PathVariable Long playSessionId
+    ) {
+        return playHistoryService.getPlayHistories(playSessionId);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
@@ -10,12 +10,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/play-sessions/{playSessionId}/histories")
+@RequestMapping("/api/play-sessions")
 public class PlayHistoryController {
 
     private final PlayHistoryService playHistoryService;
 
-    @GetMapping
+    @GetMapping("/{playSessionId}/histories")
     public PlayHistoryListResponse getPlayHistories(
             @PathVariable Long playSessionId
     ) {

--- a/src/main/java/com/emotory/backend/domain/playHistory/dto/response/PlayHistoryListResponse.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/dto/response/PlayHistoryListResponse.java
@@ -1,0 +1,17 @@
+package com.emotory.backend.domain.playHistory.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "플레이 기록 목록 응답")
+public record PlayHistoryListResponse(
+
+        @Schema(description = "플레이 기록 목록")
+        List<PlayHistoryResponse> histories
+) {
+
+    public static PlayHistoryListResponse from(List<PlayHistoryResponse> histories) {
+        return new PlayHistoryListResponse(histories);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/playHistory/dto/response/PlayHistoryResponse.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/dto/response/PlayHistoryResponse.java
@@ -1,0 +1,40 @@
+package com.emotory.backend.domain.playHistory.dto.response;
+
+import com.emotory.backend.domain.playHistory.entity.PlayHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "플레이 기록 응답")
+public record PlayHistoryResponse(
+
+        @Schema(description = "플레이 기록 ID", example = "1")
+        Long playHistoryId,
+
+        @Schema(description = "몇 번째 선택인지", example = "3")
+        Integer stepNumber,
+
+        @Schema(description = "선택이 발생한 노드 ID", example = "10")
+        Long nodeId,
+
+        @Schema(description = "선택한 선택지 ID", example = "25")
+        Long choiceId,
+
+        @Schema(description = "선택한 선택지 내용", example = "동굴 안으로 들어간다")
+        String choiceContent,
+
+        @Schema(description = "기록 생성 시각")
+        LocalDateTime createdAt
+) {
+
+    public static PlayHistoryResponse from(PlayHistory playHistory) {
+        return new PlayHistoryResponse(
+                playHistory.getPlayHistoryId(),
+                playHistory.getStepNumber(),
+                playHistory.getStoryNode().getId(),
+                playHistory.getChoice().getId(),
+                playHistory.getChoice().getContent(),
+                playHistory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/playHistory/entity/PlayHistory.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/entity/PlayHistory.java
@@ -33,4 +33,25 @@ public class PlayHistory extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "choice_id", nullable = false)
     private Choice choice;
+
+    private PlayHistory(
+            Integer stepNumber,
+            PlaySession playSession,
+            StoryNode storyNode,
+            Choice choice
+    ) {
+        this.stepNumber = stepNumber;
+        this.playSession = playSession;
+        this.storyNode = storyNode;
+        this.choice = choice;
+    }
+
+    public static PlayHistory of(
+            Integer stepNumber,
+            PlaySession playSession,
+            StoryNode storyNode,
+            Choice choice
+    ) {
+        return new PlayHistory(stepNumber, playSession, storyNode, choice);
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/playHistory/repository/PlayHistoryRepository.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/repository/PlayHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.emotory.backend.domain.playHistory.repository;
+
+import com.emotory.backend.domain.playHistory.entity.PlayHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlayHistoryRepository extends JpaRepository<PlayHistory, Long> {
+
+    int countByPlaySession_Id(Long playSessionId);
+
+    List<PlayHistory> findByPlaySession_IdOrderByStepNumberAsc(Long playSessionId);
+}

--- a/src/main/java/com/emotory/backend/domain/playHistory/service/PlayHistoryService.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/service/PlayHistoryService.java
@@ -1,0 +1,37 @@
+package com.emotory.backend.domain.playHistory.service;
+
+import com.emotory.backend.domain.playHistory.dto.response.PlayHistoryListResponse;
+import com.emotory.backend.domain.playHistory.dto.response.PlayHistoryResponse;
+import com.emotory.backend.domain.playHistory.repository.PlayHistoryRepository;
+import com.emotory.backend.domain.playSession.repository.PlaySessionRepository;
+import com.emotory.backend.global.exception.playSesstion.PlaySessionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlayHistoryService {
+
+    private final PlayHistoryRepository playHistoryRepository;
+    //@TODO PlaySession PR 머지 후 import
+    private final PlaySessionRepository playSessionRepository;
+
+    public PlayHistoryListResponse getPlayHistories(Long playSessionId) {
+        if (!playSessionRepository.existsById(playSessionId)) {
+            throw new PlaySessionNotFoundException();
+        }
+
+        //@TODO playSession PR 머지 후 연관관계 기준으로 동작 확인
+        List<PlayHistoryResponse> histories = playHistoryRepository
+                .findByPlaySession_IdOrderByStepNumberAsc(playSessionId)
+                .stream()
+                .map(PlayHistoryResponse::from)
+                .toList();
+
+        return PlayHistoryListResponse.from(histories);
+    }
+}

--- a/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     // 404 error
     NOT_FOUND(404, "존재하지 않는 리소스입니다."),
     S3_FILE_NOT_FOUND(404, "S3 파일을 찾을 수 없습니다."),
+    PLAY_HISTORY_NOT_FOUND(404, "존재하지 않는 플레이 기록입니다."),
 
     // 500 error
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),


### PR DESCRIPTION
## 📌 개요
  - #50
  - 특정 플레이 세션의 플레이 기록 목록을 조회하는 `GET /api/play-sessions/{playSessionId}/histories` API를 구현했습니다.
  - 해당 API는 `playSessionId` 기준으로 저장된 `PlayHistory`를 `stepNumber` 오름차순으로 조회합니다.

  ## 📌 작업 내용
  - `PlayHistoryController` 추가
  - `PlayHistoryService` 추가
  - `PlayHistoryRepository` 추가
  - `PlayHistoryResponse`, `PlayHistoryListResponse` 응답 DTO 추가
  - `playSessionId`에 해당하는 플레이 세션이 존재하지 않으면 `PlaySessionNotFoundException` 발생
  - 플레이 기록이 없는 경우 예외가 아니라 빈 목록 반환
  - PR 45에서 제공되는 `PlaySessionRepository`, `PlaySessionNotFoundException`, `PLAY_SESSION_NOT_FOUND`에 의존하도록 구성

  ## 📌 변경 사항
  - Controller:
    - `GET /api/play-sessions/{playSessionId}/histories` 엔드포인트 추가
    - `PathVariable`로 `playSessionId`를 받아 Service에 전달

  - Service:
    - `playSessionRepository.existsById(playSessionId)`로 플레이 세션 존재 여부 검증
    - 존재하지 않는 플레이 세션이면 `PlaySessionNotFoundException` 발생
    - `PlayHistory` 목록을 조회한 뒤 `PlayHistoryResponse`로 변환
    - `PlayHistoryListResponse`로 감싸서 반환

  - Repository:
    - `countByPlaySession_Id(Long playSessionId)` 추가
    - `findByPlaySession_IdOrderByStepNumberAsc(Long playSessionId)` 추가
    - 특정 플레이 세션의 기록을 `stepNumber` 기준 오름차순으로 조회

  ## 📌 관련 이슈
  - Closes #50

  ## 📌 참고
  - PR 45 선행 머지가 필요합니다.
  - 현재 브랜치는 PR 45에서 추가되는 아래 코드에 의존합니다.
    - `PlaySessionRepository`
    - `PlaySessionNotFoundException`
    - `ErrorCode.PLAY_SESSION_NOT_FOUND`
  - PR 45 머지 전 현재 브랜치 단독으로는 `compileJava`가 실패합니다.

  ## 📌 검증
  - `./gradlew compileJava` 실행
  - 현재는 PR 45 머지 전 의존 코드 부재로 실패 확인

  ```text
  package com.emotory.backend.domain.playSession.repository does not exist
  package com.emotory.backend.global.exception.playSesstion does not exist
```

  ## PR 체크리스트

  - [x] 이슈와 연결했는가
  - [x] 기능 단위로 작성했는가
  - [x] 테스트를 수행했는가
  - [x] 불필요한 코드가 없는가
  - [ ] 리뷰 코멘트를 반영했는가