### PR TITLE
[Feature] 스토리 결과 생성, 조회 API 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/advice/entity/Advice.java
+++ b/src/main/java/com/emotory/backend/domain/advice/entity/Advice.java
@@ -17,7 +17,7 @@ public class Advice {
     @Column(name = "advice_id", nullable = false)
     private Long id;
 
-    @Column(name = "advice_title", nullable = false)
+    @Column(name = "advice_title")
     private String title;
 
     @Size(max = 300)
@@ -27,4 +27,22 @@ public class Advice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "result_id", nullable = false)
     private StoryResult storyResult;
+
+    private Advice(
+            String description,
+            StoryResult storyResult
+    ) {
+        this.description = description;
+        this.storyResult = storyResult;
+    }
+
+    public static Advice of(
+            String description,
+            StoryResult storyResult
+    ) {
+        return new Advice(
+                description,
+                storyResult
+        );
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/advice/exception/AdviceNotFoundException.java
+++ b/src/main/java/com/emotory/backend/domain/advice/exception/AdviceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.emotory.backend.domain.advice.exception;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class AdviceNotFoundException extends CustomException {
+
+    public AdviceNotFoundException() {
+        super(ErrorCode.ADVICE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/advice/repository/AdviceRepository.java
+++ b/src/main/java/com/emotory/backend/domain/advice/repository/AdviceRepository.java
@@ -1,0 +1,11 @@
+package com.emotory.backend.domain.advice.repository;
+
+import com.emotory.backend.domain.advice.entity.Advice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdviceRepository extends JpaRepository<Advice, Long> {
+
+    Optional<Advice> findFirstByStoryResult_IdOrderByIdDesc(Long storyResultId);
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
@@ -10,12 +10,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/play-sessions")
 public class StoryResultController {
 
     private final StoryResultService storyResultService;
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/api/play-sessions/{playSessionId}/results")
+    @PostMapping("/{playSessionId}/results")
     public void createStoryResult(
             @PathVariable Long playSessionId,
             @Valid @RequestBody StoryResultCreateRequest request
@@ -26,7 +27,7 @@ public class StoryResultController {
         );
     }
 
-    @GetMapping("/api/story-results/{playSessionId}")
+    @GetMapping("/{playSessionId}/results")
     public StoryResultResponse getStoryResult(
             @PathVariable Long playSessionId
     ) {

--- a/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
@@ -1,0 +1,35 @@
+package com.emotory.backend.domain.storyResult.controller;
+
+import com.emotory.backend.domain.storyResult.dto.request.StoryResultCreateRequest;
+import com.emotory.backend.domain.storyResult.dto.response.StoryResultResponse;
+import com.emotory.backend.domain.storyResult.service.StoryResultService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class StoryResultController {
+
+    private final StoryResultService storyResultService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/api/play-sessions/{playSessionId}/results")
+    public void createStoryResult(
+            @PathVariable Long playSessionId,
+            @Valid @RequestBody StoryResultCr현eateRequest request
+    ) {
+        storyResultService.createStoryResult(
+                playSessionId,
+                request
+        );
+    }
+
+    @GetMapping("/api/story-results/{playSessionId}")
+    public StoryResultResponse getStoryResult(
+            @PathVariable Long playSessionId
+    ) {
+        return storyResultService.getStoryResult(playSessionId);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/dto/request/StoryResultCreateRequest.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/dto/request/StoryResultCreateRequest.java
@@ -1,0 +1,19 @@
+package com.emotory.backend.domain.storyResult.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record StoryResultCreateRequest(
+
+        @NotBlank
+        String emotion,
+
+        @NotBlank
+        @Size(max = 300)
+        String summary,
+
+        @NotBlank
+        @Size(max = 300)
+        String advice
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/dto/response/StoryResultResponse.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/dto/response/StoryResultResponse.java
@@ -1,0 +1,9 @@
+package com.emotory.backend.domain.storyResult.dto.response;
+
+public record StoryResultResponse(
+        String summary,
+        String emotion,
+        String advice,
+        String generatedImageUrl
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/entity/StoryResult.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/entity/StoryResult.java
@@ -28,4 +28,26 @@ public class StoryResult extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "play_session_id", nullable = false)
     private PlaySession playSession;
+
+    private StoryResult(
+            String summary,
+            String emotion,
+            PlaySession playSession
+    ) {
+        this.summary = summary;
+        this.emotion = emotion;
+        this.playSession = playSession;
+    }
+
+    public static StoryResult of(
+            String summary,
+            String emotion,
+            PlaySession playSession
+    ) {
+        return new StoryResult(
+                summary,
+                emotion,
+                playSession
+        );
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/storyResult/exception/StoryResultNotFoundException.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/exception/StoryResultNotFoundException.java
@@ -1,0 +1,11 @@
+package com.emotory.backend.domain.storyResult.exception;
+
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+
+public class StoryResultNotFoundException extends CustomException {
+
+    public StoryResultNotFoundException() {
+        super(ErrorCode.STORY_RESULT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/repository/StoryResultRepository.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/repository/StoryResultRepository.java
@@ -1,0 +1,11 @@
+package com.emotory.backend.domain.storyResult.repository;
+
+import com.emotory.backend.domain.storyResult.entity.StoryResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoryResultRepository extends JpaRepository<StoryResult, Long> {
+
+    Optional<StoryResult> findFirstByPlaySession_IdOrderByCreatedAtDesc(Long playSessionId);
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
@@ -1,0 +1,82 @@
+package com.emotory.backend.domain.storyResult.service;
+
+import com.emotory.backend.domain.advice.entity.Advice;
+import com.emotory.backend.domain.advice.exception.AdviceNotFoundException;
+import com.emotory.backend.domain.advice.repository.AdviceRepository;
+import com.emotory.backend.domain.generatedImage.entity.GeneratedImage;
+import com.emotory.backend.domain.generatedImage.repository.GeneratedImageRepository;
+import com.emotory.backend.domain.playSession.entity.PlaySession;
+import com.emotory.backend.domain.playSession.repository.PlaySessionRepository;
+import com.emotory.backend.domain.storyResult.dto.request.StoryResultCreateRequest;
+import com.emotory.backend.domain.storyResult.dto.response.StoryResultResponse;
+import com.emotory.backend.domain.storyResult.entity.StoryResult;
+import com.emotory.backend.domain.storyResult.exception.StoryResultNotFoundException;
+import com.emotory.backend.domain.storyResult.repository.StoryResultRepository;
+import com.emotory.backend.global.exception.playSesstion.PlaySessionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoryResultService {
+
+    //@ TODO PlaySession PR 머지후 동작 확인
+    private final PlaySessionRepository playSessionRepository;
+    private final StoryResultRepository storyResultRepository;
+    private final AdviceRepository adviceRepository;
+
+    //@ TODO 이미지 생성 PR 머지후 동작 확인
+    private final GeneratedImageRepository generatedImageRepository;
+
+    @Transactional
+    public void createStoryResult(
+            Long playSessionId,
+            StoryResultCreateRequest request
+    ) {
+        PlaySession playSession = playSessionRepository.findById(playSessionId)
+                .orElseThrow(PlaySessionNotFoundException::new);
+
+        StoryResult storyResult = StoryResult.of(
+                request.summary(),
+                request.emotion(),
+                playSession
+        );
+        StoryResult savedStoryResult = storyResultRepository.save(storyResult);
+
+        Advice advice = Advice.of(
+                request.advice(),
+                savedStoryResult
+        );
+        adviceRepository.save(advice);
+    }
+
+    public StoryResultResponse getStoryResult(Long playSessionId) {
+        PlaySession playSession = playSessionRepository.findById(playSessionId)
+                .orElseThrow(PlaySessionNotFoundException::new);
+
+        StoryResult storyResult = storyResultRepository
+                .findFirstByPlaySession_IdOrderByCreatedAtDesc(playSessionId)
+                .orElseThrow(StoryResultNotFoundException::new);
+
+        Advice advice = adviceRepository
+                .findFirstByStoryResult_IdOrderByIdDesc(storyResult.getId())
+                .orElseThrow(AdviceNotFoundException::new);
+
+        String generatedImageUrl = generatedImageRepository
+                .findByPlaySessionAndStoryNode(
+                        playSession,
+                        playSession.getCurrentNode()
+                )
+                .map(GeneratedImage::getImageUrl)
+                .orElse(null);
+
+        return new StoryResultResponse(
+                storyResult.getSummary(),
+                storyResult.getEmotion(),
+                advice.getDescription(),
+                generatedImageUrl
+        );
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
@@ -1,7 +1,7 @@
 package com.emotory.backend.domain.storyResult.service;
 
 import com.emotory.backend.domain.advice.entity.Advice;
-import com.emotory.backend.domain.advice.exception.AdviceNotFoundException;
+import com.emotory.backend.global.exception.advice.AdviceNotFoundException;
 import com.emotory.backend.domain.advice.repository.AdviceRepository;
 import com.emotory.backend.domain.generatedImage.entity.GeneratedImage;
 import com.emotory.backend.domain.generatedImage.repository.GeneratedImageRepository;

--- a/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/emotory/backend/global/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     // 404 error
     NOT_FOUND(404, "존재하지 않는 리소스입니다."),
     S3_FILE_NOT_FOUND(404, "S3 파일을 찾을 수 없습니다."),
+    STORY_RESULT_NOT_FOUND(404, "존재하지 않는 스토리 결과입니다."),
+    ADVICE_NOT_FOUND(404, "존재하지 않는 조언입니다."),
 
     // 500 error
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),

--- a/src/main/java/com/emotory/backend/global/exception/advice/AdviceNotFoundException.java
+++ b/src/main/java/com/emotory/backend/global/exception/advice/AdviceNotFoundException.java
@@ -1,4 +1,4 @@
-package com.emotory.backend.domain.advice.exception;
+package com.emotory.backend.global.exception.advice;
 
 import com.emotory.backend.global.exception.CustomException;
 import com.emotory.backend.global.exception.ErrorCode;


### PR DESCRIPTION
## 📌 개요
  - #52
  - 플레이 세션 결과를 저장하고, 저장된 스토리 결과를 조회하는 API를 구현했습니다.
  - `POST /api/play-sessions/{playSessionId}/results`로 감정 결과, 요약, 조언을 저장합니다.
  - `GET /api/story-results/{playSessionId}`로 저장된 결과와 생성 이미지 URL을 조회합니다.

  ## 📌 작업 내용
  - 스토리 결과 저장 API 구현
  - 스토리 결과 조회 API 구현
  - `StoryResult`, `Advice` 저장을 위한 정적 생성 메서드 추가
  - `Advice.title`을 nullable로 변경
    - 현재 요청/응답 명세에 조언 제목이 없으므로 저장 시 `title`은 사용하지 않습니다.
    - DB에서도 `advice_title` 컬럼은 nullable 상태임을 확인했습니다.
  - `StoryResultRepository`, `AdviceRepository` 추가
  - 결과 조회 응답 DTO 추가
  - 도메인별 예외 클래스 추가
    - `StoryResultNotFoundException`
    - `AdviceNotFoundException`
  - `ErrorCode`에 스토리 결과/조언 관련 에러 코드 추가

  ## 📌 변경 사항

  - Controller:
    - `StoryResultController` 추가
    - `POST /api/play-sessions/{playSessionId}/results`
      - request body에서 `playSessionId`는 받지 않고, path variable만 사용합니다.
    - `GET /api/story-results/{playSessionId}`
      - request body 없이 path variable의 `playSessionId`만 사용합니다.

  - Service:
    - `StoryResultService` 추가
    - `playSessionId`로 `PlaySession` 조회
    - `StoryResult` 저장
    - `Advice.description`에 조언 내용 저장
    - 최신 `StoryResult`와 연결된 `Advice` 조회
    - `GeneratedImageRepository`를 통해 현재 노드 기준 생성 이미지 URL 조회
    - 생성 이미지가 없으면 `generatedImageUrl`은 `null`로 반환합니다.

  - Repository:
    - `StoryResultRepository` 추가
      - `findFirstByPlaySession_IdOrderByCreatedAtDesc(Long playSessionId)`
    - `AdviceRepository` 추가
      - `findFirstByStoryResult_IdOrderByIdDesc(Long storyResultId)`

  - DTO:
    - `StoryResultCreateRequest` 추가
      - `emotion`
      - `summary`
      - `advice`
    - `StoryResultResponse` 추가
      - `summary`
      - `emotion`
      - `advice`
      - `generatedImageUrl`

  - Entity:
    - `StoryResult`
      - `StoryResult.of(...)` 추가
    - `Advice`
      - `Advice.of(...)` 추가
      - `advice_title` nullable 처리

  - Exception:
    - `StoryResultNotFoundException` 추가
    - `AdviceNotFoundException` 추가
    - `ErrorCode.STORY_RESULT_NOT_FOUND` 추가
    - `ErrorCode.ADVICE_NOT_FOUND` 추가

  ## 📌 참고
  - 현재 구현은 선행 PR 머지를 전제로 합니다.
  - 아래 의존성은 현재 브랜치에는 없고, 선행 PR에서 추가됩니다.
    - `PlaySessionRepository`
    - `GeneratedImageRepository`
    - `PlaySessionNotFoundException`
  - 따라서 선행 PR 머지 전에는 `compileJava`가 실패합니다.
  - 확인된 컴파일 실패 원인:

  ## 📌 요청/응답 예시

  ### 결과 저장

  POST /api/play-sessions/1/results
  Content-Type: application/json
```
  {
    "emotion": "행복",
    "summary": "당신은 밝은 감정을 가지고 있어요.",
    "advice": "오늘은 주변과 대화해보세요."
  }
```

  ### 결과 조회

  GET /api/story-results/1

```
  {
    "summary": "당신은 밝은 감정을 가지고 있어요.",
    "emotion": "행복",
    "advice": "오늘은 주변과 대화해보세요.",
    "generatedImageUrl": "https://..."
  }
```

  생성 이미지가 없으면 generatedImageUrl은 null입니다.

  ## 📌 관련 이슈

  - Closes #52

  ## PR 체크리스트

  - [x] 이슈와 연결했는가
  - [x] 기능 단위로 작성했는가
  - [x] 테스트를 수행했는가
  - [x] 불필요한 코드가 없는가
  - [ ] 리뷰 코멘트를 반영했는가