### PR TITLE
[Refactor] Swagger 문서 정리

### DIFF
--- a/src/main/java/com/emotory/backend/domain/choice/controller/ChoiceController.java
+++ b/src/main/java/com/emotory/backend/domain/choice/controller/ChoiceController.java
@@ -14,6 +14,7 @@ public class ChoiceController implements ChoiceControllerDocs {
 
     private final ChoiceService choiceService;
 
+    @Override
     @PostMapping("/{playSessionId}/choices")
     public ChoiceSelectResponse selectChoice(
             @PathVariable

--- a/src/main/java/com/emotory/backend/domain/choice/controller/docs/ChoiceControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/choice/controller/docs/ChoiceControllerDocs.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(
-        name = "Choice",
+        name = "선택지",
         description = "스토리 선택지 진행 API"
 )
 public interface ChoiceControllerDocs {

--- a/src/main/java/com/emotory/backend/domain/image/controller/AiImageController.java
+++ b/src/main/java/com/emotory/backend/domain/image/controller/AiImageController.java
@@ -2,6 +2,7 @@ package com.emotory.backend.domain.image.controller;
 
 import com.emotory.backend.domain.image.dto.request.AiImageGenerateRequest;
 import com.emotory.backend.domain.image.dto.response.AiImageGenerateResponse;
+import com.emotory.backend.domain.image.controller.docs.AiImageControllerDocs;
 import com.emotory.backend.domain.image.service.AiImageGenerateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,10 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
-public class AiImageController {
+public class AiImageController implements AiImageControllerDocs {
 
     private final AiImageGenerateService aiImageGenerateService;
 
+    @Override
     @PostMapping("/generate")
     public AiImageGenerateResponse generateImage(
             @RequestBody AiImageGenerateRequest request

--- a/src/main/java/com/emotory/backend/domain/image/controller/docs/AiImageControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/image/controller/docs/AiImageControllerDocs.java
@@ -1,0 +1,16 @@
+package com.emotory.backend.domain.image.controller.docs;
+
+import com.emotory.backend.domain.image.dto.request.AiImageGenerateRequest;
+import com.emotory.backend.domain.image.dto.response.AiImageGenerateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "이미지")
+public interface AiImageControllerDocs {
+
+    @Operation(summary = "AI 이미지 생성", description = "얼굴 이미지와 스토리 노드를 기반으로 AI 이미지를 생성합니다.")
+    AiImageGenerateResponse generateImage(
+            @RequestBody AiImageGenerateRequest request
+    );
+}

--- a/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
@@ -1,5 +1,6 @@
 package com.emotory.backend.domain.playHistory.controller;
 
+import com.emotory.backend.domain.playHistory.controller.docs.PlayHistoryControllerDocs;
 import com.emotory.backend.domain.playHistory.dto.response.PlayHistoryListResponse;
 import com.emotory.backend.domain.playHistory.service.PlayHistoryService;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/play-sessions")
-public class PlayHistoryController {
+public class PlayHistoryController implements PlayHistoryControllerDocs {
 
     private final PlayHistoryService playHistoryService;
 
+    @Override
     @GetMapping("/{playSessionId}/histories")
     public PlayHistoryListResponse getPlayHistories(
             @PathVariable Long playSessionId

--- a/src/main/java/com/emotory/backend/domain/playHistory/controller/docs/PlayHistoryControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/controller/docs/PlayHistoryControllerDocs.java
@@ -1,0 +1,17 @@
+package com.emotory.backend.domain.playHistory.controller.docs;
+
+import com.emotory.backend.domain.playHistory.dto.response.PlayHistoryListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "플레이 히스토리")
+public interface PlayHistoryControllerDocs {
+
+    @Operation(summary = "플레이 히스토리 목록 조회", description = "플레이 세션 ID로 선택 진행 히스토리를 조회합니다.")
+    PlayHistoryListResponse getPlayHistories(
+            @Parameter(description = "플레이 세션 ID")
+            @PathVariable Long playSessionId
+    );
+}

--- a/src/main/java/com/emotory/backend/domain/playSession/controller/PlaySessionController.java
+++ b/src/main/java/com/emotory/backend/domain/playSession/controller/PlaySessionController.java
@@ -16,6 +16,7 @@ public class PlaySessionController implements PlaySessionControllerDocs {
     private final PlaySessionService playSessionService;
 
     // 플레이 세션 생성
+    @Override
     @PostMapping
     public PlaySessionResponse create(
             @Valid
@@ -29,6 +30,7 @@ public class PlaySessionController implements PlaySessionControllerDocs {
     }
 
     // 플레이 세션 조회
+    @Override
     @GetMapping("/{playSessionId}")
     public PlaySessionResponse get(
             @PathVariable Long playSessionId
@@ -40,6 +42,7 @@ public class PlaySessionController implements PlaySessionControllerDocs {
     }
 
     // 플레이 종료
+    @Override
     @PatchMapping("/{playSessionId}/end")
     public void end(
             @PathVariable Long playSessionId

--- a/src/main/java/com/emotory/backend/domain/playSession/controller/docs/PlaySessionControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/playSession/controller/docs/PlaySessionControllerDocs.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(
-        name = "PlaySession",
+        name = "플레이 세션",
         description = "스토리 플레이 세션 API"
 )
 public interface PlaySessionControllerDocs {

--- a/src/main/java/com/emotory/backend/domain/story/controller/docs/StoryControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/story/controller/docs/StoryControllerDocs.java
@@ -7,6 +7,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "이야기")
 public interface StoryControllerDocs {
 
-    @Operation(summary = "이야기 목록 조회")
+    @Operation(summary = "이야기 목록 조회", description = "사용자가 선택할 수 있는 이야기 목록을 조회합니다.")
     StoryListResponse getStories();
 }

--- a/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
@@ -1,5 +1,6 @@
 package com.emotory.backend.domain.storyResult.controller;
 
+import com.emotory.backend.domain.storyResult.controller.docs.StoryResultControllerDocs;
 import com.emotory.backend.domain.storyResult.dto.request.StoryResultCreateRequest;
 import com.emotory.backend.domain.storyResult.dto.response.StoryResultResponse;
 import com.emotory.backend.domain.storyResult.service.StoryResultService;
@@ -11,10 +12,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/play-sessions")
-public class StoryResultController {
+public class StoryResultController implements StoryResultControllerDocs {
 
     private final StoryResultService storyResultService;
 
+    @Override
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{playSessionId}/results")
     public void createStoryResult(
@@ -27,6 +29,7 @@ public class StoryResultController {
         );
     }
 
+    @Override
     @GetMapping("/{playSessionId}/results")
     public StoryResultResponse getStoryResult(
             @PathVariable Long playSessionId

--- a/src/main/java/com/emotory/backend/domain/storyResult/controller/docs/StoryResultControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/controller/docs/StoryResultControllerDocs.java
@@ -1,0 +1,26 @@
+package com.emotory.backend.domain.storyResult.controller.docs;
+
+import com.emotory.backend.domain.storyResult.dto.request.StoryResultCreateRequest;
+import com.emotory.backend.domain.storyResult.dto.response.StoryResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "스토리 결과")
+public interface StoryResultControllerDocs {
+
+    @Operation(summary = "스토리 결과 생성", description = "플레이 세션의 스토리 결과를 저장합니다.")
+    void createStoryResult(
+            @Parameter(description = "플레이 세션 ID")
+            @PathVariable Long playSessionId,
+            @RequestBody StoryResultCreateRequest request
+    );
+
+    @Operation(summary = "스토리 결과 조회", description = "플레이 세션 ID로 스토리 결과를 조회합니다.")
+    StoryResultResponse getStoryResult(
+            @Parameter(description = "플레이 세션 ID")
+            @PathVariable Long playSessionId
+    );
+}

--- a/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
@@ -1,5 +1,6 @@
 package com.emotory.backend.global.s3.controller;
 
+import com.emotory.backend.global.s3.controller.docs.S3ControllerDocs;
 import com.emotory.backend.global.s3.dto.request.PresignedUploadRequest;
 import com.emotory.backend.global.s3.dto.response.PresignedUrlResponse;
 import com.emotory.backend.global.s3.service.PresignedS3Service;
@@ -13,11 +14,12 @@ import java.net.URL;
 @RestController
 @RequestMapping("/api/s3")
 @RequiredArgsConstructor
-public class S3Controller {
+public class S3Controller implements S3ControllerDocs {
 
     private final PresignedS3Service presignedS3Service;
     private final S3FileService s3FileService;
 
+    @Override
     @PostMapping("/presigned-upload")
     public PresignedUrlResponse getPreSignedUploadUrl(
             @Valid @RequestBody PresignedUploadRequest request

--- a/src/main/java/com/emotory/backend/global/s3/controller/docs/S3ControllerDocs.java
+++ b/src/main/java/com/emotory/backend/global/s3/controller/docs/S3ControllerDocs.java
@@ -1,0 +1,16 @@
+package com.emotory.backend.global.s3.controller.docs;
+
+import com.emotory.backend.global.s3.dto.request.PresignedUploadRequest;
+import com.emotory.backend.global.s3.dto.response.PresignedUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "파일 업로드")
+public interface S3ControllerDocs {
+
+    @Operation(summary = "Presigned Upload URL 발급", description = "S3 파일 업로드를 위한 Presigned URL과 객체 key를 발급합니다.")
+    PresignedUrlResponse getPreSignedUploadUrl(
+            @RequestBody PresignedUploadRequest request
+    );
+}


### PR DESCRIPTION
## 📌 개요
  - Swagger API 문서가 누락되었거나 실제 Controller 구현과 연결되지 않은 부분을 보완했습니
  다.
  - Controller가 각 Docs 인터페이스를 구현하도록 연결하고, Swagger 태그/설명 문구를 한글
  기준으로 정리했습니다.

  ## 📌 작업 내용
  - `AiImageController`, `StoryResultController`, `PlayHistoryController`, `S3Controller`
  에 Swagger Docs 인터페이스를 연결했습니다.
  - 누락되어 있던 `AiImageControllerDocs`, `StoryResultControllerDocs`,
  `PlayHistoryControllerDocs`, `S3ControllerDocs`를 작성했습니다.
  - Docs 인터페이스를 구현하는 Controller 메서드에 `@Override`를 추가했습니다.
  - Swagger 태그명을 한글로 통일했습니다.
    - `PlaySession` → `플레이 세션`
    - `Choice` → `선택지`
  - `이야기 목록 조회` API에 description을 추가했습니다.

  ## 📌 변경 사항
  - Controller:
    - Docs 인터페이스를 구현하도록 `implements` 추가
    - Docs 구현 메서드에 `@Override` 추가
    - `AiImage`, `StoryResult`, `PlayHistory`, `S3` Controller 문서 연결

  - Service:
    - 변경 없음

  - Repository:
    - 변경 없음

  ## 📌 관련 이슈
  - Closes #55

  ## PR 체크리스트
  - [x] 이슈와 연결했는가
  - [x] 기능 단위로 작성했는가
  - [x] 테스트를 수행했는가
  - [x] 불필요한 코드가 없는가
  - [ ] 리뷰 코멘트를 반영했는가

 ## 📸  스크린샷
<img width="723" height="643" alt="image" src="https://github.com/user-attachments/assets/e73f891e-dace-4528-ba18-53bf2845a286" />
