### PR TITLE
[Feat] 스토리 json 저장 api 기능 구현

### DIFF
--- a/src/main/java/com/emotory/backend/domain/choice/entity/Choice.java
+++ b/src/main/java/com/emotory/backend/domain/choice/entity/Choice.java
@@ -25,4 +25,16 @@ public class Choice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id", nullable = false)
     private StoryNode storyNode;
+
+    public static Choice create(
+            StoryNode storyNode,
+            String content,
+            StoryNode nextNode
+    ) {
+        Choice choice = new Choice();
+        choice.storyNode = storyNode;
+        choice.content = content;
+        choice.nextNode = nextNode;
+        return choice;
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/choice/repository/ChoiceRepository.java
+++ b/src/main/java/com/emotory/backend/domain/choice/repository/ChoiceRepository.java
@@ -1,10 +1,13 @@
 package com.emotory.backend.domain.choice.repository;
 
 import com.emotory.backend.domain.choice.entity.Choice;
+import com.emotory.backend.domain.storyNode.entity.StoryNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ChoiceRepository extends JpaRepository<Choice, Long> {
     List<Choice> findByStoryNode_IdOrderByIdAsc(Long storyNodeId);
+
+    void deleteAllByStoryNodeIn(List<StoryNode> storyNodes);
 }

--- a/src/main/java/com/emotory/backend/domain/choice/service/ChoiceService.java
+++ b/src/main/java/com/emotory/backend/domain/choice/service/ChoiceService.java
@@ -6,7 +6,7 @@ import com.emotory.backend.domain.choice.entity.Choice;
 import com.emotory.backend.domain.choice.repository.ChoiceRepository;
 import com.emotory.backend.domain.playSession.entity.PlaySession;
 import com.emotory.backend.domain.playSession.repository.PlaySessionRepository;
-import com.emotory.backend.global.exception.Choice.ChoiceNotFoundException;
+import com.emotory.backend.global.exception.choice.ChoiceNotFoundException;
 import com.emotory.backend.global.exception.playSession.PlaySessionNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/interactive-stories")
+@RequestMapping("/interactive-stories")
 public class InteractiveStoryController {
 
     private final InteractiveStoryService interactiveStoryService;

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
@@ -1,5 +1,6 @@
 package com.emotory.backend.domain.interactiveStory.controller;
 
+import com.emotory.backend.domain.interactiveStory.controller.docs.InteractiveStoryControllerDocs;
 import com.emotory.backend.domain.interactiveStory.dto.request.InteractiveStoryCreateRequest;
 import com.emotory.backend.domain.interactiveStory.dto.response.InteractiveStoryCreateResponse;
 import com.emotory.backend.domain.interactiveStory.service.InteractiveStoryService;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/interactive-stories")
-public class InteractiveStoryController {
+public class InteractiveStoryController implements InteractiveStoryControllerDocs {
 
     private final InteractiveStoryService interactiveStoryService;
 

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/controller/InteractiveStoryController.java
@@ -1,0 +1,32 @@
+package com.emotory.backend.domain.interactiveStory.controller;
+
+import com.emotory.backend.domain.interactiveStory.dto.request.InteractiveStoryCreateRequest;
+import com.emotory.backend.domain.interactiveStory.dto.response.InteractiveStoryCreateResponse;
+import com.emotory.backend.domain.interactiveStory.service.InteractiveStoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interactive-stories")
+public class InteractiveStoryController {
+
+    private final InteractiveStoryService interactiveStoryService;
+
+    @PostMapping
+    public InteractiveStoryCreateResponse create(
+            @Valid @RequestBody InteractiveStoryCreateRequest request
+    ) {
+        return interactiveStoryService.create(request);
+    }
+
+    @DeleteMapping("/{storyId}")
+    public ResponseEntity<Void> delete(
+            @PathVariable Long storyId
+    ) {
+        interactiveStoryService.deleteStory(storyId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/controller/docs/InteractiveStoryControllerDocs.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/controller/docs/InteractiveStoryControllerDocs.java
@@ -1,0 +1,105 @@
+package com.emotory.backend.domain.interactiveStory.controller.docs;
+
+import com.emotory.backend.domain.interactiveStory.dto.request.InteractiveStoryCreateRequest;
+import com.emotory.backend.domain.interactiveStory.dto.response.InteractiveStoryCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "인터랙티브 스토리 저장")
+public interface InteractiveStoryControllerDocs {
+
+    @Operation(
+            summary = "인터랙티브 스토리 생성 API",
+            description = """
+
+                    인터랙티브 스토리 JSON 데이터를 저장합니다.
+
+                    - STORY 노드와 ENDING 노드를 분리 저장합니다.
+                    - 선택지와 다음 노드 관계를 함께 저장합니다.
+                    - JSON 내부 임시 노드 ID를 실제 DB StoryNode와 매핑합니다.
+
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "인터랙티브 스토리 생성 성공",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = InteractiveStoryCreateResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 값",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    examples = @ExampleObject(
+                            value = """
+
+                                    {
+                                      "status": 400,
+                                      "message": "잘못된 입력입니다."
+                                    }
+
+                                    """
+                    )
+            )
+    )
+    InteractiveStoryCreateResponse create(
+
+            @Valid
+            @RequestBody
+            InteractiveStoryCreateRequest request
+
+    );
+
+    @Operation(
+            summary = "인터랙티브 스토리 삭제 API",
+            description = """
+
+                    인터랙티브 스토리를 삭제합니다.
+
+                    - Choice 데이터를 먼저 삭제합니다.
+                    - 이후 StoryNode 데이터를 삭제합니다.
+                    - 마지막으로 Story 데이터를 삭제합니다.
+
+                    """
+    )
+    @ApiResponse(
+            responseCode = "204",
+            description = "인터랙티브 스토리 삭제 성공"
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "스토리를 찾을 수 없음",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    examples = @ExampleObject(
+                            value = """
+
+                                    {
+                                      "status": 404,
+                                      "message": "스토리를 찾을 수 없습니다."
+                                    }
+
+                                    """
+                    )
+            )
+    )
+    ResponseEntity<Void> delete(
+
+            @Parameter(description = "스토리 ID", example = "1")
+            @PathVariable Long storyId
+
+    );
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/InteractiveStoryCreateRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/InteractiveStoryCreateRequest.java
@@ -1,0 +1,15 @@
+package com.emotory.backend.domain.interactiveStory.dto.request;
+
+import com.emotory.backend.domain.story.entity.Emotion;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record InteractiveStoryCreateRequest(
+        @NotNull Emotion emotion,
+        @NotBlank String title,
+        @NotBlank String description,
+        @NotNull Integer maxDepth,
+        @Valid @NotNull StoryFlowRequest story
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/InteractiveStoryCreateRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/InteractiveStoryCreateRequest.java
@@ -1,15 +1,33 @@
 package com.emotory.backend.domain.interactiveStory.dto.request;
 
 import com.emotory.backend.domain.story.entity.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "인터랙티브 스토리 생성 요청")
 public record InteractiveStoryCreateRequest(
-        @NotNull Emotion emotion,
-        @NotBlank String title,
-        @NotBlank String description,
-        @NotNull Integer maxDepth,
-        @Valid @NotNull StoryFlowRequest story
+
+        @Schema(description = "스토리 대표 감정", example = "HAPPY")
+        @NotNull(message = "감정은 필수입니다.")
+        Emotion emotion,
+
+        @Schema(description = "스토리 제목", example = "처음으로 무대에서 노래했어요")
+        @NotBlank(message = "스토리 제목은 필수입니다.")
+        String title,
+
+        @Schema(description = "스토리 설명", example = "발표회에서 노래를 부르며 기쁨과 자신감을 느끼는 이야기")
+        @NotBlank(message = "스토리 설명은 필수입니다.")
+        String description,
+
+        @Schema(description = "스토리 최대 깊이", example = "3")
+        @NotNull(message = "최대 깊이는 필수입니다.")
+        Integer maxDepth,
+
+        @Schema(description = "스토리 흐름 데이터")
+        @Valid
+        @NotNull(message = "스토리 데이터는 필수입니다.")
+        StoryFlowRequest story
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryChoiceRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryChoiceRequest.java
@@ -1,10 +1,21 @@
 package com.emotory.backend.domain.interactiveStory.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "스토리 선택지 요청")
 public record StoryChoiceRequest(
-        @NotBlank String id,
-        @NotBlank String text,
-        @NotBlank String nextNodeId
+
+        @Schema(description = "선택지 임시 ID", example = "1")
+        @NotBlank(message = "선택지 ID는 필수입니다.")
+        String id,
+
+        @Schema(description = "선택지 내용", example = "친구들과 기쁨을 나눴어요")
+        @NotBlank(message = "선택지 내용은 필수입니다.")
+        String text,
+
+        @Schema(description = "다음 노드 ID", example = "1-1")
+        @NotBlank(message = "다음 노드 ID는 필수입니다.")
+        String nextNodeId
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryChoiceRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryChoiceRequest.java
@@ -1,0 +1,10 @@
+package com.emotory.backend.domain.interactiveStory.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StoryChoiceRequest(
+        @NotBlank String id,
+        @NotBlank String text,
+        @NotBlank String nextNodeId
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryEndingRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryEndingRequest.java
@@ -1,0 +1,12 @@
+package com.emotory.backend.domain.interactiveStory.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StoryEndingRequest(
+        @NotBlank String selectedChoiceText,
+        @NotBlank String summary,
+        @NotBlank String emotionLabel,
+        @NotBlank String contentSummary,
+        @NotBlank String advice
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryEndingRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryEndingRequest.java
@@ -1,12 +1,29 @@
 package com.emotory.backend.domain.interactiveStory.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "스토리 엔딩 요청")
 public record StoryEndingRequest(
-        @NotBlank String selectedChoiceText,
-        @NotBlank String summary,
-        @NotBlank String emotionLabel,
-        @NotBlank String contentSummary,
-        @NotBlank String advice
+
+        @Schema(description = "사용자가 선택한 선택지", example = "친구들과 기쁨을 나눴어요")
+        @NotBlank(message = "선택 선택지는 필수입니다.")
+        String selectedChoiceText,
+
+        @Schema(description = "스토리 요약", example = "행복한 발표회였어요.")
+        @NotBlank(message = "요약은 필수입니다.")
+        String summary,
+
+        @Schema(description = "감정 라벨", example = "기쁨 😊")
+        @NotBlank(message = "감정 라벨은 필수입니다.")
+        String emotionLabel,
+
+        @Schema(description = "엔딩 내용 요약", example = "친구들과 함께 행복한 시간을 보냈어요.")
+        @NotBlank(message = "내용 요약은 필수입니다.")
+        String contentSummary,
+
+        @Schema(description = "감정 조언", example = "행복한 순간은 함께 나누면 더 커져요.")
+        @NotBlank(message = "조언은 필수입니다.")
+        String advice
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryFlowRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryFlowRequest.java
@@ -1,13 +1,23 @@
 package com.emotory.backend.domain.interactiveStory.dto.request;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
+@Schema(description = "스토리 흐름 요청")
 public record StoryFlowRequest(
-    @NotBlank String rootNodeId,
-    @Valid @NotEmpty List<StoryNodeRequest> nodes
+
+        @Schema(description = "루트 노드 ID", example = "1")
+        @NotBlank(message = "루트 노드 ID는 필수입니다.")
+        String rootNodeId,
+
+        @ArraySchema(schema = @Schema(implementation = StoryNodeRequest.class))
+        @Valid
+        @NotEmpty(message = "노드 목록은 비어있을 수 없습니다.")
+        List<StoryNodeRequest> nodes
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryFlowRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryFlowRequest.java
@@ -1,0 +1,13 @@
+package com.emotory.backend.domain.interactiveStory.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record StoryFlowRequest(
+    @NotBlank String rootNodeId,
+    @Valid @NotEmpty List<StoryNodeRequest> nodes
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryNodeRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryNodeRequest.java
@@ -1,0 +1,18 @@
+package com.emotory.backend.domain.interactiveStory.dto.request;
+
+import com.emotory.backend.domain.interactiveStory.entity.StoryNodeType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record StoryNodeRequest(
+        @NotBlank String id,
+        @NotNull StoryNodeType type,
+        @NotNull Integer depth,
+        String content,
+        @Valid List<StoryChoiceRequest> choices,
+        StoryEndingRequest ending
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryNodeRequest.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/request/StoryNodeRequest.java
@@ -1,18 +1,37 @@
 package com.emotory.backend.domain.interactiveStory.dto.request;
 
 import com.emotory.backend.domain.interactiveStory.entity.StoryNodeType;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
+@Schema(description = "스토리 노드 요청")
 public record StoryNodeRequest(
-        @NotBlank String id,
-        @NotNull StoryNodeType type,
-        @NotNull Integer depth,
+
+        @Schema(description = "노드 임시 ID", example = "1-1")
+        @NotBlank(message = "노드 ID는 필수입니다.")
+        String id,
+
+        @Schema(description = "노드 타입", example = "STORY")
+        @NotNull(message = "노드 타입은 필수입니다.")
+        StoryNodeType type,
+
+        @Schema(description = "노드 깊이", example = "2")
+        @NotNull(message = "노드 깊이는 필수입니다.")
+        Integer depth,
+
+        @Schema(description = "스토리 내용", example = "친구들과 함께 웃으며 즐거운 시간을 보냈어요.")
         String content,
-        @Valid List<StoryChoiceRequest> choices,
+
+        @ArraySchema(schema = @Schema(implementation = StoryChoiceRequest.class))
+        @Valid
+        List<StoryChoiceRequest> choices,
+
+        @Schema(description = "엔딩 데이터")
         StoryEndingRequest ending
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/response/InteractiveStoryCreateResponse.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/response/InteractiveStoryCreateResponse.java
@@ -1,0 +1,6 @@
+package com.emotory.backend.domain.interactiveStory.dto.response;
+
+public record InteractiveStoryCreateResponse(
+        Long storyId
+) {
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/dto/response/InteractiveStoryCreateResponse.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/dto/response/InteractiveStoryCreateResponse.java
@@ -1,6 +1,11 @@
 package com.emotory.backend.domain.interactiveStory.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "인터랙티브 스토리 생성 응답")
 public record InteractiveStoryCreateResponse(
+
+        @Schema(description = "생성된 스토리 ID", example = "1")
         Long storyId
 ) {
 }

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/entity/StoryNodeType.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/entity/StoryNodeType.java
@@ -1,0 +1,6 @@
+package com.emotory.backend.domain.interactiveStory.entity;
+
+public enum StoryNodeType {
+    STORY,
+    ENDING
+}

--- a/src/main/java/com/emotory/backend/domain/interactiveStory/service/InteractiveStoryService.java
+++ b/src/main/java/com/emotory/backend/domain/interactiveStory/service/InteractiveStoryService.java
@@ -1,0 +1,148 @@
+package com.emotory.backend.domain.interactiveStory.service;
+
+import com.emotory.backend.domain.choice.entity.Choice;
+import com.emotory.backend.domain.choice.repository.ChoiceRepository;
+import com.emotory.backend.domain.interactiveStory.dto.request.*;
+import com.emotory.backend.domain.interactiveStory.dto.response.InteractiveStoryCreateResponse;
+import com.emotory.backend.domain.interactiveStory.entity.StoryNodeType;
+import com.emotory.backend.domain.story.entity.Story;
+import com.emotory.backend.domain.story.repository.StoryRepository;
+import com.emotory.backend.domain.storyNode.entity.StoryNode;
+import com.emotory.backend.domain.storyNode.repository.StoryNodeRepository;
+import com.emotory.backend.global.exception.CustomException;
+import com.emotory.backend.global.exception.ErrorCode;
+import com.emotory.backend.global.exception.storyNode.StoryNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InteractiveStoryService {
+
+    private final StoryRepository storyRepository;
+    private final StoryNodeRepository storyNodeRepository;
+    private final ChoiceRepository choiceRepository;
+
+    public InteractiveStoryCreateResponse create(InteractiveStoryCreateRequest request) {
+        validateStory(request);
+
+        Story story = Story.create(
+                request.title(),
+                request.description(),
+                request.emotion()
+        );
+
+        Story savedStory = storyRepository.save(story);
+
+        Map<String, StoryNode> nodeMap = new HashMap<>();
+
+        int nodeOrder = 1;
+
+        for (StoryNodeRequest nodeRequest : request.story().nodes()) {
+            boolean isEnding = nodeRequest.type() == StoryNodeType.ENDING;
+
+            String content = isEnding
+                    ? buildEndingContent(nodeRequest.ending())
+                    : nodeRequest.content();
+
+            StoryNode storyNode = StoryNode.create(
+                    savedStory,
+                    content,
+                    nodeOrder++,
+                    isEnding,
+                    request.emotion()
+            );
+
+            StoryNode savedNode = storyNodeRepository.save(storyNode);
+            nodeMap.put(nodeRequest.id(), savedNode);
+        }
+
+        for (StoryNodeRequest nodeRequest : request.story().nodes()) {
+            if (nodeRequest.choices() == null || nodeRequest.choices().isEmpty()) {
+                continue;
+            }
+
+            StoryNode currentNode = nodeMap.get(nodeRequest.id());
+
+            for (StoryChoiceRequest choiceRequest : nodeRequest.choices()) {
+                StoryNode nextNode = nodeMap.get(choiceRequest.nextNodeId());
+
+                Choice choice = Choice.create(
+                        currentNode,
+                        choiceRequest.text(),
+                        nextNode
+                );
+
+                choiceRepository.save(choice);
+            }
+        }
+
+        return new InteractiveStoryCreateResponse(savedStory.getId());
+    }
+
+    private void validateStory(InteractiveStoryCreateRequest request) {
+        Map<String, StoryNodeRequest> nodeMap = new HashMap<>();
+
+        for (StoryNodeRequest node : request.story().nodes()) {
+            if (nodeMap.containsKey(node.id())) {
+                throw new CustomException(ErrorCode.INVALID_INPUT);
+            }
+            nodeMap.put(node.id(), node);
+        }
+
+        if (!nodeMap.containsKey(request.story().rootNodeId())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        for (StoryNodeRequest node : request.story().nodes()) {
+            if (node.type() == StoryNodeType.STORY) {
+                if (node.content() == null || node.content().isBlank()) {
+                    throw new CustomException(ErrorCode.INVALID_INPUT);
+                }
+
+                if (node.choices() == null || node.choices().isEmpty()) {
+                    throw new CustomException(ErrorCode.INVALID_INPUT);
+                }
+
+                for (StoryChoiceRequest choice : node.choices()) {
+                    if (!nodeMap.containsKey(choice.nextNodeId())) {
+                        throw new CustomException(ErrorCode.INVALID_INPUT);
+                    }
+                }
+            }
+
+            if (node.type() == StoryNodeType.ENDING && node.ending() == null) {
+                throw new CustomException(ErrorCode.INVALID_INPUT);
+            }
+        }
+    }
+
+    private String buildEndingContent(StoryEndingRequest ending) {
+        return String.join("\n",
+                ending.summary(),
+                "느낀 감정: " + ending.emotionLabel(),
+                "내용 요약: " + ending.contentSummary(),
+                "이런 감정이 들 때는요: " + ending.advice()
+        );
+    }
+
+    public void deleteStory(Long storyId) {
+        Story story = storyRepository.findById(storyId)
+                .orElseThrow(StoryNotFoundException::new);
+
+        List<StoryNode> storyNodes = storyNodeRepository.findAllByStory(story);
+
+        if (!storyNodes.isEmpty()) {
+            choiceRepository.deleteAllByStoryNodeIn(storyNodes);
+            storyNodeRepository.deleteAll(storyNodes);
+        }
+
+        storyRepository.delete(story);
+    }
+}

--- a/src/main/java/com/emotory/backend/domain/story/entity/Story.java
+++ b/src/main/java/com/emotory/backend/domain/story/entity/Story.java
@@ -23,4 +23,16 @@ public class Story {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Emotion emotion;
+
+    public static Story create(
+            String title,
+            String description,
+            Emotion emotion
+    ) {
+        Story story = new Story();
+        story.title = title;
+        story.description = description;
+        story.emotion = emotion;
+        return story;
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/storyNode/entity/StoryNode.java
+++ b/src/main/java/com/emotory/backend/domain/storyNode/entity/StoryNode.java
@@ -32,4 +32,20 @@ public class StoryNode {
     @Enumerated(EnumType.STRING)
     @Column(name = "node_emotion")
     private Emotion emotion;
+
+    public static StoryNode create(
+            Story story,
+            String content,
+            Integer nodeOrder,
+            Boolean isEnding,
+            Emotion emotion
+    ) {
+        StoryNode storyNode = new StoryNode();
+        storyNode.story = story;
+        storyNode.content = content;
+        storyNode.nodeOrder = nodeOrder;
+        storyNode.isEnding = isEnding;
+        storyNode.emotion = emotion;
+        return storyNode;
+    }
 }

--- a/src/main/java/com/emotory/backend/domain/storyNode/repository/StoryNodeRepository.java
+++ b/src/main/java/com/emotory/backend/domain/storyNode/repository/StoryNodeRepository.java
@@ -4,6 +4,7 @@ import com.emotory.backend.domain.story.entity.Story;
 import com.emotory.backend.domain.storyNode.entity.StoryNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StoryNodeRepository extends JpaRepository<StoryNode,Long> {
@@ -12,4 +13,6 @@ public interface StoryNodeRepository extends JpaRepository<StoryNode,Long> {
     findFirstByStoryOrderByNodeOrderAsc(
             Story story
     );
+
+    List<StoryNode> findAllByStory(Story story);
 }

--- a/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/service/StoryResultService.java
@@ -10,7 +10,7 @@ import com.emotory.backend.domain.playSession.repository.PlaySessionRepository;
 import com.emotory.backend.domain.storyResult.dto.request.StoryResultCreateRequest;
 import com.emotory.backend.domain.storyResult.dto.response.StoryResultResponse;
 import com.emotory.backend.domain.storyResult.entity.StoryResult;
-import com.emotory.backend.domain.storyResult.exception.StoryResultNotFoundException;
+import com.emotory.backend.global.exception.storyResult.StoryResultNotFoundException;
 import com.emotory.backend.domain.storyResult.repository.StoryResultRepository;
 import com.emotory.backend.global.exception.playSession.PlaySessionNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/emotory/backend/global/exception/choice/ChoiceNotFoundException.java
+++ b/src/main/java/com/emotory/backend/global/exception/choice/ChoiceNotFoundException.java
@@ -1,4 +1,4 @@
-package com.emotory.backend.global.exception.Choice;
+package com.emotory.backend.global.exception.choice;
 
 import com.emotory.backend.global.exception.CustomException;
 import com.emotory.backend.global.exception.ErrorCode;

--- a/src/main/java/com/emotory/backend/global/exception/storyResult/StoryResultNotFoundException.java
+++ b/src/main/java/com/emotory/backend/global/exception/storyResult/StoryResultNotFoundException.java
@@ -1,4 +1,4 @@
-package com.emotory.backend.domain.storyResult.exception;
+package com.emotory.backend.global.exception.storyResult;
 
 import com.emotory.backend.global.exception.CustomException;
 import com.emotory.backend.global.exception.ErrorCode;


### PR DESCRIPTION
## 📌 개요
- 인터랙티브 스토리 JSON 데이터를 기반으로 `story`, `story_node`, `choice` 테이블에 분리 저장하는 기능을 구현했습니다.
- 선택지 선택 시 다음 `StoryNode`로 자연스럽게 이동할 수 있도록 노드 간 연결 구조를 개선했습니다.
- STORY / ENDING 노드를 구분하여 저장하도록 구조를 정리했습니다.

## 📌 작업 내용
- 인터랙티브 스토리 생성 API 구현
- 인터랙티브 스토리 삭제 API 구현
- JSON 내부 노드 ID와 실제 DB `StoryNode` 엔티티 매핑 로직 구현
- STORY 노드 / ENDING 노드 분리 저장 처리
- ENDING 데이터를 문자열 형태로 변환하여 `StoryNode.content`에 저장
- 선택지(`Choice`)와 다음 노드(`nextNode`) 연관관계 연결
- 스토리 삭제 시 선택지 → 노드 → 스토리 순으로 삭제되도록 처리
- 엔티티 생성 책임을 위한 정적 생성 메서드 추가

## 📌 변경 사항

### Controller
- `InteractiveStoryController` 추가
- `POST /api/interactive-stories` API 추가
- `DELETE /api/interactive-stories/{storyId}` API 추가

### Service
- `InteractiveStoryService` 추가
- JSON 요청 데이터 검증 로직 추가
- `Story`, `StoryNode`, `Choice` 저장 로직 구현
- JSON 노드 ID와 DB 노드 엔티티 매핑 처리
- ENDING 데이터 문자열 변환 처리
- 선택지 선택 시 `Choice.nextNode` 기준으로 다음 노드 이동 처리
- 스토리 삭제 로직 구현

### Repository
- `StoryNodeRepository.findAllByStory(...)` 추가
- `ChoiceRepository.deleteAllByStoryNodeIn(...)` 추가

### Entity
- `Story`, `StoryNode`, `Choice` 정적 생성 메서드 추가
- `Choice` → `StoryNode(nextNode)` 연관관계 추가 및 저장 구조 개선

## 📌 관련 이슈
- Closes #54

## ✅ PR 체크리스트
- [x] 이슈와 연결했는가
- [x] 기능 단위로 작성했는가
- [x] 테스트를 수행했는가
- [x] 불필요한 코드가 없는가
- [ ] 리뷰 코멘트를 반영했는가