### PR TITLE
[Refactor] API EndPoint 수정

### DIFF
--- a/src/main/java/com/emotory/backend/domain/choice/controller/ChoiceController.java
+++ b/src/main/java/com/emotory/backend/domain/choice/controller/ChoiceController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/play-sessions")
+@RequestMapping("/play-sessions")
 public class ChoiceController implements ChoiceControllerDocs {
 
     private final ChoiceService choiceService;

--- a/src/main/java/com/emotory/backend/domain/image/controller/AiImageController.java
+++ b/src/main/java/com/emotory/backend/domain/image/controller/AiImageController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/images")
+@RequestMapping("/images")
 @RequiredArgsConstructor
 public class AiImageController implements AiImageControllerDocs {
 

--- a/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/emotory/backend/domain/member/controller/MemberController.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController implements MemberControllerDocs {
 

--- a/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
+++ b/src/main/java/com/emotory/backend/domain/playHistory/controller/PlayHistoryController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/play-sessions")
+@RequestMapping("/play-sessions")
 public class PlayHistoryController implements PlayHistoryControllerDocs {
 
     private final PlayHistoryService playHistoryService;

--- a/src/main/java/com/emotory/backend/domain/playSession/controller/PlaySessionController.java
+++ b/src/main/java/com/emotory/backend/domain/playSession/controller/PlaySessionController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/play-sessions")
+@RequestMapping("/play-sessions")
 public class PlaySessionController implements PlaySessionControllerDocs {
 
     private final PlaySessionService playSessionService;

--- a/src/main/java/com/emotory/backend/domain/story/controller/StoryController.java
+++ b/src/main/java/com/emotory/backend/domain/story/controller/StoryController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/stories")
+@RequestMapping("/stories")
 public class StoryController implements StoryControllerDocs {
 
     private final StoryService storyService;

--- a/src/main/java/com/emotory/backend/domain/storyNode/controller/StoryNodeController.java
+++ b/src/main/java/com/emotory/backend/domain/storyNode/controller/StoryNodeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/story-nodes")
+@RequestMapping("/story-nodes")
 public class StoryNodeController implements StoryNodeControllerDocs {
 
     private final StoryNodeService storyNodeService;

--- a/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
+++ b/src/main/java/com/emotory/backend/domain/storyResult/controller/StoryResultController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/play-sessions")
+@RequestMapping("/play-sessions")
 public class StoryResultController implements StoryResultControllerDocs {
 
     private final StoryResultService storyResultService;

--- a/src/main/java/com/emotory/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/emotory/backend/global/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         ).permitAll()
 
                         // S3 업로드 허용
-                        .requestMatchers("/api/s3/**").permitAll()
+                        .requestMatchers("/s3/**").permitAll()
 
                         // 전체 허용
                         .anyRequest().permitAll()

--- a/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
+++ b/src/main/java/com/emotory/backend/global/s3/controller/S3Controller.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URL;
 
 @RestController
-@RequestMapping("/api/s3")
+@RequestMapping("/s3")
 @RequiredArgsConstructor
 public class S3Controller implements S3ControllerDocs {
 


### PR DESCRIPTION
## 📌 개요
  - API 엔드포인트에서 공통 prefix로 사용하던 `/api`를 제거했습니다.

  ## 📌 작업 내용
  - 모든 Controller의 `@RequestMapping` 경로에서 `/api` prefix를 제거했습니다.
  - S3 업로드 허용 경로가 변경된 엔드포인트와 맞도록 Security 설정을 수정했습니다.
  - 기존 하위 리소스 경로와 HTTP method 매핑은 그대로 유지했습니다.

  ## 📌 변경 사항
  - Controller:
    - `/api/stories` → `/stories`
    - `/api/members` → `/members`
    - `/api/play-sessions` → `/play-sessions`
    - `/api/story-nodes` → `/story-nodes`
    - `/api/images` → `/images`
    - `/api/s3` → `/s3`

  - Service:
    - 변경 사항 없음

  - Repository:
    - 변경 사항 없음

  ## 📌 관련 이슈
  - Closes #59

  ## PR 체크리스트
  - [x] 이슈와 연결했는가
  - [x] 기능 단위로 작성했는가
  - [ ] 테스트를 수행했는가
  - [x] 불필요한 코드가 없는가
  - [ ] 리뷰 코멘트를 반영했는가

## 📸 스크린샷

<img width="821" height="672" alt="image" src="https://github.com/user-attachments/assets/63d72898-d0ba-4ef4-afb2-ec65500f2ae5" />
